### PR TITLE
Update webpack.config.js to match Video 2

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
   },
   module: {
     loaders: [
-      {test: /\.js$/, exclude: /node_modules/, loader: "babel-loader"}
+      {test: /\.js$/, include: __dirname + '/app', loader: "babel-loader"}
     ]
   },
   plugins: [HTMLWebpackPluginConfig]


### PR DESCRIPTION
During video 2, around minutes 11 and 12, `exclude: /node_modules/` magically turns into `include: __dirname + '/app'`, without explanation. I'd recommend changing it in this branch, to match how the code ends up in the video, and also because it's more common to use `include` than `exclude`. It'd probably be helpful if you could splice a mention of `include` into the video as well. But maybe you mention it in a future video?
