### PR TITLE
Added semicolon to UserDetails.js

### DIFF
--- a/app/components/UserDetails.js
+++ b/app/components/UserDetails.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var PropTypes = React.PropTypes
+var PropTypes = React.PropTypes;
 
 function UserDetails (user) {
   return (


### PR DESCRIPTION
Semicolon was forgotten on "var PropTypes = React.PropTypes"
