### PR TITLE
declare error

### DIFF
--- a/app/components/Popular.js
+++ b/app/components/Popular.js
@@ -54,7 +54,7 @@ export default class Popular extends React.Component {
         repos,
         error: null,
       }))
-      .catch(() => {
+      .catch((error) => {
         console.warn('Error fetching repos: ', error)
 
         this.setState({


### PR DESCRIPTION
need to declare error as argument to catch handler to avoid unresolved symbol during catch