### PR TITLE
This throws an error for me if an error occurs, as the `error` on lin…

### DIFF
--- a/app/components/Popular.js
+++ b/app/components/Popular.js
@@ -54,8 +54,8 @@ export default class Popular extends React.Component {
         repos,
         error: null,
       }))
-      .catch(() => {
-        console.warn('Error fetching repos: ', error)
+      .catch((err) => {
+        console.warn('Error fetching repos: ', err)
 
         this.setState({
           error: `There was an error fetching the repositories.`


### PR DESCRIPTION
…e 58 isn't defined.

I changed it to pass the error message thrown to the catch clause, and then pass that to the console.